### PR TITLE
Publish mcp-server-o1js

### DIFF
--- a/packages/mcp-server-o1js/package.json
+++ b/packages/mcp-server-o1js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-server-o1js",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Model Context Protocol server for o1js",
   "license": "MIT",
   "main": "dist/src/index.js",


### PR DESCRIPTION
This PR bumps version of `mcp-server-o1js` to `0.1.1` from `0.1.0` to trigger npm publish workflow.